### PR TITLE
BS-14754 - display source object ID instead of ID in case of an archived

### DIFF
--- a/main/features/user/tasks/list/tasks-details.html
+++ b/main/features/user/tasks/list/tasks-details.html
@@ -28,7 +28,7 @@
         </li>
         <li class="list-group-item">
           <span class="ListGroup-label">case ID&nbsp;:</span>
-          {{currentCase.id}}
+          {{currentCase.sourceObjectId || currentCase.id}}
         </li>
         <li class="list-group-item">
           <span class="ListGroup-label">Started by&nbsp;:</span>


### PR DESCRIPTION
case