### PR TITLE
BS-14643 - stop using window.top.location and use window.parent.location instead

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
     "angular-ui-tree": "2.9.0",
     "angular-xeditable": "vitalets/angular-xeditable#0.1.8",
     "animate.css": "3.1.1",
-    "bonita-js-components": "bonitasoft/bonita-js-components#0.5.19",
+    "bonita-js-components": "bonitasoft/bonita-js-components#0.5.22",
     "bootstrap": "3.3.2",
     "bootstrap-tags": "1.1.5",
     "bootstrap-toggle": "2.0.0",

--- a/main/common/resources/resources.js
+++ b/main/common/resources/resources.js
@@ -110,7 +110,7 @@
         'responseError': function(rejection) {
 
           if (rejection.status === 401 && !/\/API\/platform\/license/.test(rejection.config.url)) {
-            $window.top.location.reload();
+            $window.parent.location.reload();
           }
           return $q.reject(rejection);
         }

--- a/main/common/services/topLocationFactory.js
+++ b/main/common/services/topLocationFactory.js
@@ -33,12 +33,12 @@
       return Object.create({}, {
         _pf: {
           get: function () {
-            return grab(/_pf=([1-9]*)/).from($window.top.location.hash);
+            return grab(/_pf=([1-9]*)/).from($window.parent.location.hash);
           }
         },
         tenant: {
           get: function () {
-            return grab(/tenant=([1-9]*)/).from($window.top.location.search);
+            return grab(/tenant=([1-9]*)/).from($window.parent.location.search);
           }
         }
       });

--- a/test/spec/common/resources/resources.spec.js
+++ b/test/spec/common/resources/resources.spec.js
@@ -20,7 +20,7 @@
   describe('Resources API', function() {
 
     var mockWindow = {
-        top: {
+        parent: {
           'location': {
             reload: function() {}
           }
@@ -106,37 +106,37 @@
 
       it('should reload parent when back end respond 401', function() {
         expect(unauthorizedResponseHandler).toBeDefined();
-        spyOn(mockWindow.top.location, 'reload');
+        spyOn(mockWindow.parent.location, 'reload');
 
         unauthorizedResponseHandler.responseError({
           status: 401,
           config: {url: 'http://anyhost:8080/bonita/API/anyApi'}
         });
 
-        expect(mockWindow.top.location.reload).toHaveBeenCalled();
+        expect(mockWindow.parent.location.reload).toHaveBeenCalled();
       });
 
       it('should not reload parent otherwise', function() {
         expect(unauthorizedResponseHandler).toBeDefined();
-        spyOn(mockWindow.top.location, 'reload');
+        spyOn(mockWindow.parent.location, 'reload');
 
         unauthorizedResponseHandler.responseError({
           status: 404
         });
 
-        expect(mockWindow.top.location.reload).not.toHaveBeenCalled();
+        expect(mockWindow.parent.location.reload).not.toHaveBeenCalled();
       });
 
       it('should not reload parent if 401 due to platform license', function() {
         expect(unauthorizedResponseHandler).toBeDefined();
-        spyOn(mockWindow.top.location, 'reload');
+        spyOn(mockWindow.parent.location, 'reload');
 
         unauthorizedResponseHandler.responseError({
           status: 401,
           config: {url: 'http://anyhost:8080/bonita/API/platform/license'}
         });
 
-        expect(mockWindow.top.location.reload).not.toHaveBeenCalled();
+        expect(mockWindow.parent.location.reload).not.toHaveBeenCalled();
       });
     });
 

--- a/test/spec/common/services/manage-top-url.spec.js
+++ b/test/spec/common/services/manage-top-url.spec.js
@@ -22,7 +22,7 @@
     var mockedWindow;
     beforeEach(function(){
       mockedWindow = {
-        top : {
+        parent : {
           location:{}
         }
       };
@@ -36,8 +36,8 @@
     describe('getUrlToTokenAndId function', function(){
       beforeEach(function () {
         spyOn(manageTopUrl, 'getCurrentProfile').and.returnValue('_pf=2');
-        mockedWindow.top.location.pathname = '/bonita/portal/homepage';
-        mockedWindow.top.location.search = '?tenant=1';
+        mockedWindow.parent.location.pathname = '/bonita/portal/homepage';
+        mockedWindow.parent.location.search = '?tenant=1';
       });
       it('should change top location hash to case detail', function () {
         expect(manageTopUrl.getUrlToTokenAndId()).toBe('/bonita/portal/homepage?tenant=1#?id=&_p=&_pf=2');
@@ -53,29 +53,29 @@
     describe('retrieve current profile from top Url', function(){
       it('should not throw error when no top or hash empty', function(){
         expect(manageTopUrl.getCurrentProfile()).toBeUndefined();
-        delete mockedWindow.top;
+        delete mockedWindow.parent;
         expect(manageTopUrl.getCurrentProfile()).toBeUndefined();
       });
       it('should find _pf=2 from top window', function(){
-        mockedWindow.top.location.hash = '?_p=ng-caselistingadmin&_pf=2';
+        mockedWindow.parent.location.hash = '?_p=ng-caselistingadmin&_pf=2';
         expect(manageTopUrl.getCurrentProfile()).toBe('_pf=2');
-        mockedWindow.top.location.hash = '?_pf=372&_p=ng-caselistingadmin';
+        mockedWindow.parent.location.hash = '?_pf=372&_p=ng-caselistingadmin';
         expect(manageTopUrl.getCurrentProfile()).toBe('_pf=372');
-        mockedWindow.top.location.hash = '?_p=ng-caselistingadmin&_pf=452&_pf=6';
+        mockedWindow.parent.location.hash = '?_p=ng-caselistingadmin&_pf=452&_pf=6';
         expect(manageTopUrl.getCurrentProfile()).toBe('_pf=452');
-        mockedWindow.top.location.hash = '_pf=122';
+        mockedWindow.parent.location.hash = '_pf=122';
         expect(manageTopUrl.getCurrentProfile()).toBe('_pf=122');
       });
     });
     describe('getCurrentPageToken', function(){
       it('should find the page token from top window\'s hash', function(){
-        mockedWindow.top.location.hash = '?_p=ng-caselistingadmin&_pf=2';
+        mockedWindow.parent.location.hash = '?_p=ng-caselistingadmin&_pf=2';
         expect(manageTopUrl.getCurrentPageToken()).toBe('ng-caselistingadmin');
-        mockedWindow.top.location.hash = '?_pf=372&_p=caselistingadmin';
+        mockedWindow.parent.location.hash = '?_pf=372&_p=caselistingadmin';
         expect(manageTopUrl.getCurrentPageToken()).toBe('caselistingadmin');
-        mockedWindow.top.location.hash = '?_p=ng-caselisting&_pf=452&_pf=6';
+        mockedWindow.parent.location.hash = '?_p=ng-caselisting&_pf=452&_pf=6';
         expect(manageTopUrl.getCurrentPageToken()).toBe('ng-caselisting');
-        mockedWindow.top.location.hash = '_pf=122';
+        mockedWindow.parent.location.hash = '_pf=122';
         expect(manageTopUrl.getCurrentPageToken()).toBe('');
       });
     });

--- a/test/spec/common/services/topLocationFactory.spec.js
+++ b/test/spec/common/services/topLocationFactory.spec.js
@@ -22,7 +22,7 @@ describe('topLocationFactory', function () {
   beforeEach(module('org.bonitasoft.services.navigation'));
 
   beforeEach(function () {
-    $window = {top: {location: {}}};
+    $window = {parent: {location: {}}};
 
     module(function ($provide) {
       $provide.value('$window', $window);
@@ -34,7 +34,7 @@ describe('topLocationFactory', function () {
   });
 
   it('should retrieve profile from top window hash', function () {
-    $window.top.location.hash = '_pf=2';
+    $window.parent.location.hash = '_pf=2';
     expect(topLocation._pf).toBe('2');
   });
 
@@ -43,7 +43,7 @@ describe('topLocationFactory', function () {
   });
 
   it('should retrieve tenant from top window query string', function () {
-    $window.top.location.search = 'tenant=4';
+    $window.parent.location.search = 'tenant=4';
     expect(topLocation.tenant).toBe('4');
   });
 


### PR DESCRIPTION
The goal of this PR is to be able to display the portal pages inside an IFrame without the top URL being changed every time you navigate. (see BS-14643).
To merge with https://github.com/bonitasoft/bonita-portal-js-sp/pull/105