### PR TITLE
fix(BS-14704) Tooltip displays {{ XXX}} when cursor is between two lines

### DIFF
--- a/main/features/user/tasks/list/tasks-table.html
+++ b/main/features/user/tasks/list/tasks-table.html
@@ -84,7 +84,7 @@
           </td>
 
           <td class="text-right">{{::task.id}}</td>
-          <td class="Ellipsis" title="{{::task.displayName}}">{{::task.displayName}}</td>
+          <td class="Ellipsis"><div title="{{::task.displayName}}">{{::task.displayName}}</div></td>
           <td style="Ellipsis" title="{{::task.displayDescription}}">{{::task.displayDescription}}</td>
           <td class="text-right Cell--sortable">{{::task.caseId}}</td>
           <td class="Ellipsis">{{::task.rootContainerId.name}}</td>


### PR DESCRIPTION
Tooltip was wrong since it was a td attribute and td has a padding.
Moving tooltip from td to td content

Fixes [BS-14704](https://bonitasoft.atlassian.net/browse/BS-14704)