### PR TITLE
BS-14717 - The dropdown to filter on process is not refreshed

### DIFF
--- a/main/features/user/tasks/list/tasks-app.js
+++ b/main/features/user/tasks/list/tasks-app.js
@@ -107,6 +107,7 @@
        */
       this.setProcess = function(process) {
         store.request.process = process;
+        this.updateCount();
         this.updateTasks();
       };
 
@@ -177,8 +178,9 @@
       };
 
       this.updateAll = function() {
-        this.updateCount();
-        this.updateTasks();
+        var currentProcess = store.request.process;
+        this.updateProcessList();
+        this.setProcess(currentProcess);
       };
 
       /**

--- a/main/features/user/tasks/list/tasks-list.html
+++ b/main/features/user/tasks/list/tasks-list.html
@@ -133,7 +133,6 @@
                 <task-details current-task="app.currentTask"
                               current-case="app.currentCase"
                               refresh-count="app.updateCount()"
-                              refresh-all="app.updateAll()"
                               editable="app.currentTask.assigned_id === app.user.user_id"
                               hide-form="app.request.taskFilter === app.TASK_FILTERS.DONE"
                               inactive="app.tasks.length === 0">

--- a/main/templates.js
+++ b/main/templates.js
@@ -37,9 +37,10 @@ angular.module('portalTemplates/admin/applications/applications-list.html', []).
     '        <td class="application-display-name" title="{{ application.displayName }}">{{ application.displayName }}</td>\n' +
     '        <td class="application-version" title="{{ application.version }}">{{ application.version }}</td>\n' +
     '        <td class="application-path">\n' +
-    '          <a target="_blank" title="../apps/{{ application.token }}" ng-href="../apps/{{ application.token }}"> ../apps/{{application.token}}</a>\n' +
+    '          <a target="_blank" title="../apps/{{ application.token }}" ng-href="../apps/{{ application.token }}" ng-disabled="!application.profileId.name"> ../apps/{{application.token}}</a>\n' +
     '        </td>\n' +
-    '        <td class="application-profile" title="{{ application.profileId.name }}">{{ application.profileId.name }}</td>\n' +
+    '        <td ng-if="application.profileId.name" class="application-profile" title="{{ application.profileId.name }}">{{ application.profileId.name }}</td>\n' +
+    '        <td ng-if="!application.profileId.name" class="application-profile"><span tooltip="{{ \'No profile mapped to this application\' | translate }}" class="glyphicon glyphicon-warning-sign text-warning"></span></td>\n' +
     '        <td class="application-last-update-date" aria-label="{{ application.lastUpdateDate | dateI18n:\'YYYY-MM-DD HH:mm:ss\'}}">\n' +
     '          <span class="clickable" popover="{{applicationsListCtrl.loadTemplatePopover(application)}}" popover-trigger="mouseenter">{{ application.lastUpdateDate | dateAgo }}</span>\n' +
     '        </td>\n' +
@@ -497,7 +498,7 @@ angular.module('portalTemplates/admin/applications/edit-application.html', []).r
     '    <bootstrap-form-control form="application.form" class="select-form-container" label="{{ \'Profile\' | translate }}">\n' +
     '      <select id="profile"\n' +
     '              name="profile" ng-model="application.model.profileId"\n' +
-    '              ng-options="profile.id as profile.name for profile in profiles"></select>\n' +
+    '              ng-options="profile.id as profile.name for profile in profiles" required></select>\n' +
     '    </bootstrap-form-control>\n' +
     '\n' +
     '\n' +
@@ -1865,7 +1866,6 @@ angular.module('portalTemplates/user/tasks/list/tasks-list.html', []).run(['$tem
     '                <task-details current-task="app.currentTask"\n' +
     '                              current-case="app.currentCase"\n' +
     '                              refresh-count="app.updateCount()"\n' +
-    '                              refresh-all="app.updateAll()"\n' +
     '                              editable="app.currentTask.assigned_id === app.user.user_id"\n' +
     '                              hide-form="app.request.taskFilter === app.TASK_FILTERS.DONE"\n' +
     '                              inactive="app.tasks.length === 0">\n' +

--- a/test/spec/features/user/tasks/list/tasks-app.spec.js
+++ b/test/spec/features/user/tasks/list/tasks-app.spec.js
@@ -286,17 +286,17 @@ describe('taskApp', function(){
     });
 
     describe('updateAll', function(){
-      it('should trigger updateTasks & updateCount', function(){
+      it('should trigger updateProcessList, updateTasks & updateCount', function(){
         spyOn(controller, 'updateTasks');
         spyOn(controller, 'updateCount');
+        spyOn(controller, 'updateProcessList');
 
         controller.updateAll();
+        expect(controller.updateProcessList).toHaveBeenCalled();
         expect(controller.updateCount).toHaveBeenCalled();
         expect(controller.updateTasks).toHaveBeenCalled();
       });
     });
-
-
 
     describe('updateProcessList', function(){
       var store;


### PR DESCRIPTION
The dropdown to filter on process was not refreshed when clicking of the refresh button. Needed to reload the page with F5
Fix: call updateProcessList() function (which itself calls updateTasks() and updateCount())
Fixes [BS-14717](https://bonitasoft.atlassian.net/browse/BS-14717)