### PR TITLE
tr(dev) Make proxy port configurable

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -145,7 +145,7 @@ module.exports = function (grunt) {
             return {
               context: context,
               host: 'localhost',
-              port: 8080,
+              port: grunt.option('proxyport') || 8080,
               https: false,
               changeOrigin: false,
               xforward: false


### PR DESCRIPTION
Based on #107

Allow to launch serve task and specify server proxy port

```
grunt serve --proxyport=8282
```