### PR TITLE
tr(build) Create e2e reports folder before launching them

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "karma-phantomjs-launcher": "0.1.4",
     "karma-safari-launcher": "0.1.1",
     "load-grunt-tasks": "0.4.0",
+    "mkdirp": "0.5.1",
     "ngdocs": "0.1.0",
     "node-xml-lite": "0.0.5",
     "protractor": "2.0.0",

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -34,8 +34,11 @@ exports.config = {
   // The require statement must be down here, since jasmine-reporters
   // needs jasmine to be in the global and protractor does not guarantee
   // this until inside the onPrepare function.
+    var reports = 'target/reports/e2e/';
+    require('mkdirp')(reports);
+
     require('jasmine-reporters');
     jasmine.getEnv().addReporter(
-      new jasmine.JUnitXmlReporter('target/reports/e2e/'));
+      new jasmine.JUnitXmlReporter(reports));
   }
 };


### PR DESCRIPTION
We specify reports folder in protractor conf but jasmine JUnitXmlReporter doesn't create it.
So we need to do it if needed


Fixes bos_web_portal-js-e2e job on fast2 CI