### PR TITLE
feat(BS-14505) Store table preferences in local storage

### DIFF
--- a/main/features/user/tasks/list/common/preference.js
+++ b/main/features/user/tasks/list/common/preference.js
@@ -1,9 +1,5 @@
-(function() {
+(function () {
   'use strict';
-
-  angular
-    .module('org.bonitasoft.features.user.tasks.app.pref', ['ngCookies', 'org.bonitasoft.features.user.tasks.app.config'])
-
 
   /**
    * preference service
@@ -20,88 +16,68 @@
    *  - {Array}   max         Array of boolean representing columns visibility
    *                            for list only layout
    */
-  .service('preference', [
-    '$cookies',
-    'DEFAULT_DETAILS',
-    'COLUMNS_SETTINGS',
-    function($cookies, DEFAULT_DETAILS, COLUMNS_SETTINGS) {
-      var dict = angular.extend({
-        'showDetails': DEFAULT_DETAILS,
-        'lastTab': '',
-      }, COLUMNS_SETTINGS);
+  angular
+    .module('org.bonitasoft.features.user.tasks.app.pref', [ 'ngStorage', 'org.bonitasoft.features.user.tasks.app.config' ])
+    .service('preference', ['$localStorage', 'DEFAULT_DETAILS', 'COLUMNS_SETTINGS',
 
-      /**
-       * @internal Check is key is allowed
-       * @param  {String} key
-       * @throws {Error} If key is not allowed
-       */
-      function check(key) {
-        if (!dict.hasOwnProperty(key)) {
-          throw new Error('preference key not found');
+      function ($localStorage, DEFAULT_DETAILS, COLUMNS_SETTINGS) {
+        var STORAGEKEY = 'bonita-user-task-list';
+
+        var dict = angular.extend({
+          'showDetails': DEFAULT_DETAILS,
+          'showFilters': true,
+          'lastTab': ''
+        }, COLUMNS_SETTINGS);
+
+        $localStorage[STORAGEKEY] = angular.merge(dict, $localStorage[STORAGEKEY] || {});
+
+        /**
+         * @internal Check is key is allowed
+         * @param  {String} key
+         * @throws {Error} If key is not allowed
+         */
+        function check(key) {
+          if (!dict.hasOwnProperty(key)) {
+            throw new Error('preference key not found');
+          }
         }
-      }
 
-      /**
-       * Return mode depending on items shown in view and screen size
-       * @param  {Boolean} showDetails   are task details shown
-       * @param  {Boolean} isSmallScreen is screen width
-       * @return {String}                min|prop|all
-       */
-      this.getMode = function(showDetails, isSmallScreen) {
-        if (isSmallScreen) {
-          return 'min';
-        } else if (showDetails) {
-          return 'mid';
-        } else {
-          return 'max';
-        }
-      };
+        /**
+         * Return mode depending on items shown in view and screen size
+         * @param  {Boolean} showDetails   are task details shown
+         * @param  {Boolean} isSmallScreen is screen width
+         * @return {String}                min|prop|all
+         */
+        this.getMode = function (showDetails, isSmallScreen) {
+          if (isSmallScreen) {
+            return 'min';
+          } else if (showDetails) {
+            return 'mid';
+          } else {
+            return 'max';
+          }
+        };
 
-      /**
-       * Get preference corresponding to key
-       * @param  {String} key
-       * @return {Object}     corresponding preference
-       */
-      this.get = function(key) {
-        check.call(this, key);
-        return preferences[key];
-      };
+        /**
+         * Get preference corresponding to key
+         * @param  {String} key
+         * @return {Object}     corresponding preference
+         */
+        this.get = function (key) {
+          check.call(this, key);
+          return $localStorage[STORAGEKEY][key];
+        };
 
-      /**
-       * Set a preference
-       * @param {String}  key     preference name
-       * @param {Object}  value   preference value
-       * @param {Boolean} persist persist preference to cookie
-       */
-      this.set = function(key, value, persist) {
-        check.call(this, key);
+        /**
+         * Set a preference
+         * @param {String}  key     preference name
+         * @param {Object}  value   preference value
+         */
+        this.set = function (key, value) {
+          check.call(this, key);
+          $localStorage[STORAGEKEY][key] = value;
+        };
+      }]);
 
-        persist = persist || false;
-        preferences[key] = value;
 
-        if (persist) {
-          $cookies.put(key, JSON.stringify(value));
-        }
-      };
-
-      /**
-       * flush preference stored in the cookie
-       */
-      this.flush = function() {
-        angular.forEach(dict, function(value, key) {
-          $cookies.remove(key);
-        });
-      };
-
-      var preferences = {};
-
-      angular.forEach(dict, function(value, key) {
-        preferences[key] = JSON.parse($cookies.get(key) || 'null');
-
-        if (preferences[key] === null) {
-          preferences[key] = value;
-        }
-      });
-    }
-  ]);
 })();

--- a/main/features/user/tasks/list/tasks-app.js
+++ b/main/features/user/tasks/list/tasks-app.js
@@ -68,7 +68,7 @@
       this.showDetails = preference.get('showDetails') === true;
       this.smallScreen = screen.size.name === 'sm';
 
-      this.showMenu = true;
+      this.showMenu = preference.get('showFilters');
       this.expandDetails = false;
 
       this.getMode = preference.getMode;
@@ -222,7 +222,7 @@
        * @param  {boolean} showDetails are details shown
        */
       this.updateLayout = function(showDetails) {
-        preference.set('showDetails', showDetails, true);
+        preference.set('showDetails', showDetails);
       };
 
 
@@ -392,6 +392,11 @@
           }
         }
       };
+
+      this.toggleFilters = function() {
+        this.showMenu = !this.showMenu;
+        preference.set('showFilters', this.showMenu);
+      }
     }
   ])
 

--- a/main/features/user/tasks/list/tasks-details.js
+++ b/main/features/user/tasks/list/tasks-details.js
@@ -56,7 +56,7 @@
         };
 
         this.saveSelectedTab = function(tab) {
-          preference.set('lastTab', tab, true);
+          preference.set('lastTab', tab);
         };
       }
     ])

--- a/main/features/user/tasks/list/tasks-list.html
+++ b/main/features/user/tasks/list/tasks-list.html
@@ -13,12 +13,12 @@
     <div class="OffcanvasMenu navbar">
       <h3 class="OffcanvasMenu-title" translate>Filters</h3>
       <button ng-if="!app.smallScreen && app.showMenu" title="{{ 'Hide Menu' | translate }}"
-        class="FilterToggle btn btn-default" btn-checkbox ng-model="app.showMenu">
+        class="FilterToggle btn btn-default"  ng-click="app.toggleFilters()">
         <span class="glyphicon glyphicon-chevron-left"></span>
         <span class="sr-only" translate>Hide menu</span>
       </button>
       <button ng-if="!app.smallScreen && !app.showMenu" title="{{ 'Show Menu' | translate }}"
-              class="FilterToggle btn btn-default" btn-checkbox ng-model="app.showMenu">
+              class="FilterToggle btn btn-default" ng-click="app.toggleFilters()">
         <span class="glyphicon glyphicon-chevron-right"></span>
         <span class="sr-only" translate>Show menu</span>
       </button>

--- a/main/features/user/tasks/list/tasks-table.js
+++ b/main/features/user/tasks/list/tasks-table.js
@@ -225,7 +225,7 @@
               var cols = columns.map(function(item) {
                 return item.visible;
               });
-              preference.set($scope.mode, cols, true);
+              preference.set($scope.mode, cols);
             };
 
             /**

--- a/test/spec/features/user/tasks/list/common/preference.spec.js
+++ b/test/spec/features/user/tasks/list/common/preference.spec.js
@@ -2,7 +2,7 @@
 
 describe('preference', function() {
   var pref;
-  var cookies;
+  var localStrorage;
   var DEFAULT_DETAILS;
   var COLUMNS_SETTINGS;
 
@@ -10,11 +10,14 @@ describe('preference', function() {
 
   beforeEach(inject( function($injector){
     pref = $injector.get('preference');
-    cookies = $injector.get('$cookies');
+    localStrorage = $injector.get('$localStorage');
     DEFAULT_DETAILS = $injector.get('DEFAULT_DETAILS');
     COLUMNS_SETTINGS = $injector.get('COLUMNS_SETTINGS');
   }));
 
+  afterEach(function() {
+    localStrorage.$reset();
+  });
 
   describe('get', function(){
 
@@ -57,19 +60,10 @@ describe('preference', function() {
     });
     it('should persists a value', function(){
       var o = {name:'abcd'};
-      pref.set('showDetails', o, true);
+      pref.set('showDetails', o);
 
-      var value = cookies.get('showDetails');
-      expect(JSON.parse(value)).toEqual(o);
-    });
-  });
-
-  describe('flush', function(){
-    it('should remove cookies', function(){
-      pref.set('max', 'coucou', true);
-      expect(cookies.get('max')).toEqual(JSON.stringify('coucou'));
-      pref.flush();
-      expect(cookies.get('max')).not.toBeDefined();
+      var value = localStrorage['bonita-user-task-list'].showDetails;
+      expect(value).toEqual(o);
     });
   });
 

--- a/test/spec/features/user/tasks/list/tasks-app.spec.js
+++ b/test/spec/features/user/tasks/list/tasks-app.spec.js
@@ -57,11 +57,13 @@ describe('taskApp', function(){
     var controller;
 
     var $q;
+    var preference;
 
     beforeEach(module('org.bonitasoft.features.user.tasks.app'));
 
     beforeEach(inject(function($injector){
       $q = $injector.get('$q');
+      preference = $injector.get('preference');
     }));
 
 
@@ -343,7 +345,7 @@ describe('taskApp', function(){
 
       it('should save preference', function(){
         controller.updateLayout(false);
-        expect(preference.set).toHaveBeenCalledWith('showDetails', false, true);
+        expect(preference.set).toHaveBeenCalledWith('showDetails', false);
       });
     });
 
@@ -464,6 +466,21 @@ describe('taskApp', function(){
       });
     });
 
+    it('should get filter panel state from preferences', function() {
+      expect(controller.showMenu).toEqual(preference.get('showFilters'));
+    });
+
+    it('should toggle filter panel and save state in preferences', function() {
+      controller.showMenu = true;
+
+      controller.toggleFilters();
+      expect(controller.showMenu).toBeFalsy();
+      expect(preference.get('showFilters')).toBeFalsy();
+
+      controller.toggleFilters();
+      expect(controller.showMenu).toBeTruthy();
+      expect(preference.get('showFilters')).toBeTruthy();
+    });
   });
 
   describe('taskApp directive', function(){

--- a/test/spec/features/user/tasks/list/tasks-detail.spec.js
+++ b/test/spec/features/user/tasks/list/tasks-detail.spec.js
@@ -58,7 +58,7 @@ describe('module tasks.details', function() {
 
     it('saveSelectedTab', function(){
       service.saveSelectedTab('toto');
-      expect(preference.set).toHaveBeenCalledWith('lastTab', 'toto',  true);
+      expect(preference.set).toHaveBeenCalledWith('lastTab', 'toto');
     });
 
     describe('takeTask', function(){

--- a/test/spec/features/user/tasks/list/tasks-table.spec.js
+++ b/test/spec/features/user/tasks/list/tasks-table.spec.js
@@ -198,7 +198,7 @@ describe('module org.bonitasoft.features.user.tasks.list.table', function() {
       it('should persist columns settings', function(){
         var isolated = element.isolateScope();
         isolated.visibilityHandler({}, cols);
-        expect(pref.set).toHaveBeenCalledWith(scope.mode, [true, false], true);
+        expect(pref.set).toHaveBeenCalledWith(scope.mode, [true, false]);
       });
     });
 


### PR DESCRIPTION
* Store all task list preferences in localstorage
* Add filter panel state in localStorage (open/closed)

For now, I've not used bo-storable since behavior was already implemented with cookies and it was easier to just move to localstorage

I'll do another following PR to use bo-storable in order to be consistent